### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ module "dcos-private-agent-instances" {
 | Name | Description |
 |------|-------------|
 | admin_username | SSH User |
+| instance_nic_ids | List of instance nic ids created by this module |
+| ip_configuration_names | List of instance nic ids created by this module |
 | prereq_id | Prereq id used for dependency |
 | private_ips | List of private ip addresses created by this module |
 | public_ips | List of public ip addresses created by this module |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,16 @@ output "public_ips" {
   value       = ["${module.dcos-private-agents-instances.public_ips}"]
 }
 
+output "instance_nic_ids" {
+  description = "List of instance nic ids created by this module"
+  value       = ["${module.dcos-private-agents-instances.instance_nic_ids}"]
+}
+
+output "ip_configuration_names" {
+  description = "List of instance nic ids created by this module"
+  value       = ["${module.dcos-private-agents-instances.ip_configuration_names}"]
+}
+
 output "prereq_id" {
   description = "Prereq id used for dependency"
   value       = "${module.dcos-private-agents-instances.prereq_id}"


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`